### PR TITLE
fix: remove hijacked polyfill.io supply-chain dependency

### DIFF
--- a/.github/workflows/quarto-publish.yml
+++ b/.github/workflows/quarto-publish.yml
@@ -24,7 +24,7 @@ jobs:
             with:
                 # To install LaTeX to build PDF book
                 tinytex: true
-                version: 1.4.554
+                version: 1.8.26
 
         -   name: Setup Python
             uses: actions/setup-python@v3

--- a/_site/projects/bigT_ros_control/index.html
+++ b/_site/projects/bigT_ros_control/index.html
@@ -107,7 +107,7 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 }</script>
 <style>html{ scroll-behavior: smooth; }</style>
 
-  <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+  <script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
   <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml-full.js" type="text/javascript"></script>
 
 <script type="text/javascript">


### PR DESCRIPTION
## Summary

The live site was serving the hijacked **`polyfill.io`** script — the 2024 supply-chain attack where the `polyfill.io` domain was sold and began serving malware to visitors. The malicious loader was injected on every page containing LaTeX math (`projects/index.html`, `blog/index.html`, `blog/posts/mamba/index.html`, both `bigT_ros_control` pages).

**Root cause:** CI pins Quarto to **`1.4.554`** in [`.github/workflows/quarto-publish.yml`](../tree/fix/polyfill-supply-chain/.github/workflows/quarto-publish.yml#L27), which emits the MathJax loader pointing at `https://polyfill.io/v3/polyfill.min.js`. Quarto switched to the safe `cdnjs.cloudflare.com` mirror in `1.5.49+`. The committed `_site/` was already clean (rendered locally with Quarto `1.8.26`), but CI re-renders `gh-pages` from scratch on every push to `main`, so the old pinned version kept reintroducing the malware.

This PR bumps the pinned version to **`1.8.26`** (matches the local toolchain) so re-renders emit the safe mirror, and scrubs the one stale `polyfill.io` reference left in the committed `_site/`.

## Changes

| File | Change |
| --- | --- |
| [`.github/workflows/quarto-publish.yml`](../tree/fix/polyfill-supply-chain/.github/workflows/quarto-publish.yml#L27) | Quarto `1.4.554` → `1.8.26` |
| [`_site/projects/bigT_ros_control/index.html`](../tree/fix/polyfill-supply-chain/_site/projects/bigT_ros_control/index.html) | Stale `polyfill.io` → `cdnjs.cloudflare.com` mirror |

## Test plan

- [x] `grep -rn "polyfill\.io" --include="*.html"` across the repo returns no script tags (only this PR description / commit message text)
- [ ] After merge: confirm the CI **Render and Publish** run succeeds with Quarto `1.8.26`
- [ ] After deploy: `curl -s https://charleneleong-ai.github.io/blog/ | grep polyfill` shows `cdnjs.cloudflare.com`, not `polyfill.io`

## Note

Merging triggers a re-render that overwrites `gh-pages` with clean output — that is what removes the malware from the live site. Until then the live `gh-pages` branch still serves `polyfill.io`; if an immediate takedown is needed before merge, the 5 deployed HTML files on `gh-pages` can be patched directly (same find/replace).